### PR TITLE
Convert all methods for parity with 'true' module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
-module.exports = function () {
-  return false;
+module.exports = function aJavaScriptPortOfTheUnixUtilityFalseReturnsTheBooleanValueFalse () {
+  return true;
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = function aJavaScriptPortOfTheUnixUtilityFalseReturnsTheBooleanValueFalse () {
-  return true;
+  return false;
 };


### PR DESCRIPTION
The 'true' module (https://github.com/mde/true) uses named functions for debugging purposes.
I use both modules and need parity of this convention.

I'm aware that it adds a lot of code, but as pointed out in the patch in the 'true' module, debugging is critical
