### PR TITLE
only publish critical files & shorten the function name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-module.exports = function aJavaScriptPortOfTheUnixUtilityFalseReturnsTheBooleanValueFalse () {
+module.exports = function returnFalse() {
   return false;
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.4",
   "description": "A JavaScript port of the Unix utility 'false'. Returns the Boolean value `false`",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "jake test"
   },


### PR DESCRIPTION
The function name seems unnecessarily long, so I changed it to `returnFalse`.

And the NPM tarball will now contain `index.js`, `README.md`, and `package.json`.